### PR TITLE
Add collapsible toggle buttons to h2 sections

### DIFF
--- a/_sass/minimal-mistakes/_base.scss
+++ b/_sass/minimal-mistakes/_base.scss
@@ -634,3 +634,37 @@ a {
   -o-border-radius: 52px;
   border-radius: 52px;
 }
+
+/* ---- Collapsible h2 sections ---- */
+.page__content h2.collapsible {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5em;
+}
+
+.section-toggle {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-size: 0.7em;
+  line-height: 1;
+  color: $muted-text-color;
+  background: none;
+  border: 1px solid $border-color;
+  border-radius: 3px;
+  padding: 0.2em 0.45em;
+  cursor: pointer;
+
+  &:hover {
+    background-color: $lighter-gray;
+    color: $text-color;
+  }
+
+  &:focus {
+    outline: 2px solid $link-color;
+    outline-offset: 2px;
+  }
+}
+
+.section-content.collapsed {
+  display: none;
+}

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -9,3 +9,44 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   });
 });
+
+// Add a collapse/expand toggle button to every h2 section in .page__content.
+document.addEventListener("DOMContentLoaded", function () {
+  var pageContent = document.querySelector(".page__content");
+  if (!pageContent) return;
+
+  Array.from(pageContent.querySelectorAll("h2")).forEach(function (h2) {
+    // Only handle h2s that are direct children of .page__content.
+    if (h2.parentElement !== pageContent) return;
+
+    // Collect all siblings between this h2 and the next sibling h2.
+    var siblings = [];
+    var next = h2.nextElementSibling;
+    while (next && !(next.tagName === "H2" && next.parentElement === pageContent)) {
+      siblings.push(next);
+      next = next.nextElementSibling;
+    }
+    if (siblings.length === 0) return;
+
+    // Wrap the siblings in a collapsible container.
+    var wrapper = document.createElement("div");
+    wrapper.className = "section-content";
+    h2.after(wrapper);
+    siblings.forEach(function (el) { wrapper.appendChild(el); });
+
+    // Append a toggle button inside the h2 (margin-left: auto pushes it right via flex).
+    h2.classList.add("collapsible");
+    var btn = document.createElement("button");
+    btn.className = "section-toggle";
+    btn.setAttribute("aria-expanded", "true");
+    btn.setAttribute("aria-label", "Collapse section");
+    btn.textContent = "▾";
+    btn.addEventListener("click", function () {
+      var nowCollapsed = wrapper.classList.toggle("collapsed");
+      btn.textContent = nowCollapsed ? "▸" : "▾";
+      btn.setAttribute("aria-expanded", String(!nowCollapsed));
+      btn.setAttribute("aria-label", nowCollapsed ? "Expand section" : "Collapse section");
+    });
+    h2.appendChild(btn);
+  });
+});


### PR DESCRIPTION
Each h2 in .page__content gets a ▾/▸ button aligned to the right
that collapses/expands the content below it. Implemented with a small
JS snippet that wraps sibling elements in a div.section-content and
toggles a .collapsed class, plus matching SCSS for the button and
the collapsed state.

https://claude.ai/code/session_01PYgc1hZfsUasp3Mpurcbj3